### PR TITLE
Changes to allow hosting dhcp server from command line on windows.

### DIFF
--- a/bin/dhcp-cli.js
+++ b/bin/dhcp-cli.js
@@ -22,6 +22,7 @@ if (serve) {
     } else if (arg === 'range') {
       opts.range = argv[arg].split('-');
     } else if (Options.conf[arg] !== undefined) {
+
       // If value is missing, minimist simply makes it true/false
       if (typeof argv[arg] !== 'boolean') {
         opts[arg] = argv[arg];

--- a/bin/dhcp-cli.js
+++ b/bin/dhcp-cli.js
@@ -10,18 +10,18 @@ var argv = require('minimist')(process.argv.slice(2));
 var opts = {};
 var force = []; // We force all options here, since the user explicitly stated the option
 
-if (path.basename(process.argv[1]).slice(-1) === 'd') {
+var serve = path.basename(process.argv[1]).slice(-1) === 'd' || argv['serve']
+
+if (serve) {
 
   // Create a server
 
   for (var arg in argv) {
-
-    if (arg === '_') {
+    if (arg === '_' || arg === 'serve') {
       /* void */
     } else if (arg === 'range') {
       opts.range = argv[arg].split('-');
     } else if (Options.conf[arg] !== undefined) {
-
       // If value is missing, minimist simply makes it true/false
       if (typeof argv[arg] !== 'boolean') {
         opts[arg] = argv[arg];

--- a/bin/dhcpd-cli.js
+++ b/bin/dhcpd-cli.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+process.title = 'node-dhcp';
+
+var path = require('path');
+var dhcp = require('../lib/dhcp.js');
+var Options = require('../lib/options.js');
+var argv = require('minimist')(process.argv.slice(2));
+
+var opts = {};
+var force = []; // We force all options here, since the user explicitly stated the option
+
+// Create a server
+
+for (var arg in argv) {
+  if (arg === '_') {
+    /* void */
+  } else if (arg === 'range') {
+    opts.range = argv[arg].split('-');
+  } else if (Options.conf[arg] !== undefined) {
+
+    // If value is missing, minimist simply makes it true/false
+    if (typeof argv[arg] !== 'boolean') {
+      opts[arg] = argv[arg];
+      force.push(argv[arg]);
+    } else {
+      console.error('Argument ' + arg + ' needs a value.');
+      process.exit();
+    }
+
+  } else if (arg === 'help') {
+    console.log('Usage:\n\tdhcpd --range 192.168.0.1-192.168.0.99 --option1 value1 --option2 value2 ...');
+    process.exit();
+  } else {
+    console.error('Invalid argument ' + arg);
+    process.exit();
+  }
+}
+
+var server = dhcp.createServer(opts);
+
+server.listen();

--- a/lib/options.js
+++ b/lib/options.js
@@ -459,7 +459,7 @@ var opts = {
     attr: 'rapidCommit'
   }, /*
    82: { // RFC 3046, relayAgentInformation
-   
+
    },*/
   116: {// RFC 2563: https://tools.ietf.org/html/rfc2563
     name: 'Auto-Configure',
@@ -476,12 +476,22 @@ var opts = {
     config: 'subnetSelection'
   }, /*
    119: { // dns search list
-   
+
    }, */
   145: {// RFC 6704: https://tools.ietf.org/html/rfc6704
     name: 'Forcerenew Nonce',
     type: 'UInt8s',
     attr: 'renewNonce'
+  },
+  1001: { // TODO: Fix my number!
+    name: 'Static',
+    config: 'static'
+  },
+  1002: { // TODO: Fix my number!
+    name: 'Random IP',
+    type: 'Bool',
+    config: 'randomIP',
+    default: true
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "bin": {
     "dhcp": "./bin/dhcp-cli.js",
-    "dhcpd": "./bin/dhcp-cli.js"
+    "dhcpd": "./bin/dhcpd-cli.js"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Tried to get things running on my windows machine and hit some roadblocks.
These changes allowed me to get a server running on Windows using the following command-line:

    node bin\dhcp-cli.js 
                         --range 192.168.50.100-192.168.50.199 
                         --hostname xxxxxxxx 
                         --server 192.168.50.1 
                         --router 192.168.50.1 
                         --serve

I had to add `--serve` because windows doesn't seem to receive the args in the same way as osx and linux.

Without the added options I was hitting "Invalid option" errors.