### PR TITLE
Allowing static binding of an IP via function

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -242,7 +242,10 @@ Server.prototype = {
 
     // Is there a static binding?
     var static = this.config('static');
-    if (static[clientMAC]) {
+    if(typeof static === "function"){
+      var staticResult = static(clientMac);
+      if(staticResult) return staticResult;
+    }else if (static[clientMAC]) {
       return static[clientMAC];
     }
 


### PR DESCRIPTION
The skinny here is that I need to be able to have a database backend to my dhcp server.  This feature allows me to do the following:

```javascript
var dhcp = require('dhcp');

var s = dhcp.createServer({
  // System settings
  range: [
    "192.168.3.10", "192.168.3.99"
  ],
  static: (clientMac)=>{
    var device = myDb.devices.find({"mac":clientMac});
    if(device) return device.ip;
    return false;
  }
});

s.listen();
```

Then if that device exists, I can set it's IP manually, if NOT then it will just continue as normal :)