### PR TITLE
Implement options for bootp paramaters

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -346,9 +346,9 @@ Server.prototype = {
       chaddr: req.chaddr, // Client mac address
       sname: '',
       file: '',
-      options: this._getOptions(Object.assign({
+      options: this._getOptions({
         53: DHCPOFFER
-      }, this._conf.sendOffer), [
+      }, [
         1, 3, 51, 54, 6
       ], req.options[55])
     };
@@ -389,9 +389,9 @@ Server.prototype = {
       chaddr: req.chaddr, // 'chaddr' from client DHCPREQUEST message
       sname: '',
       file: '',
-      options: this._getOptions(Object.assign({
+      options: this._getOptions({
         53: DHCPACK
-      }, this._conf.sendAck), [
+      }, [
         1, 3, 51, 54, 6
       ], req.options[55])
     };
@@ -420,9 +420,9 @@ Server.prototype = {
       chaddr: req.chaddr, // 'chaddr' from client DHCPREQUEST message
       sname: '', // unused
       file: '', // unused
-      options: this._getOptions(Object.assign({
+      options: this._getOptions({
         53: DHCPNAK
-      }, this._conf.sendNak), [
+      }, [
         54
       ])
     };

--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -346,9 +346,9 @@ Server.prototype = {
       chaddr: req.chaddr, // Client mac address
       sname: '',
       file: '',
-      options: this._getOptions({
+      options: this._getOptions(Object.assign({
         53: DHCPOFFER
-      }, [
+      }, this._conf.sendOffer), [
         1, 3, 51, 54, 6
       ], req.options[55])
     };
@@ -389,9 +389,9 @@ Server.prototype = {
       chaddr: req.chaddr, // 'chaddr' from client DHCPREQUEST message
       sname: '',
       file: '',
-      options: this._getOptions({
+      options: this._getOptions(Object.assign({
         53: DHCPACK
-      }, [
+      }, this._conf.sendAck), [
         1, 3, 51, 54, 6
       ], req.options[55])
     };
@@ -420,9 +420,9 @@ Server.prototype = {
       chaddr: req.chaddr, // 'chaddr' from client DHCPREQUEST message
       sname: '', // unused
       file: '', // unused
-      options: this._getOptions({
+      options: this._getOptions(Object.assign({
         53: DHCPNAK
-      }, [
+      }, this._conf.sendNak), [
         54
       ])
     };

--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -207,6 +207,19 @@ Server.prototype = {
         }
       }
     }
+
+    const forceOptions = this._conf.forceOptions
+    if (
+      forceOptions instanceof Array
+      && forceOptions.length > 0
+    ) {
+      for (const option of forceOptions) {
+        const id = Options.conf[option]
+        if (typeof id !== 'undefined') {
+          pre[id] = this.config(option)
+        }
+      }
+    }
     return pre;
   },
 


### PR DESCRIPTION
New options can be used like:
```js
dhcp.createServer({
    sendOffer: {
      72: '192.168.0.50'
    },
    sendAck: {
      72: '192.168.0.50'
    },
    sendNak: {
      72: '192.168.0.50'
    }
  })
```