### PR TITLE
fix ReferenceError: id is not defined

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -214,10 +214,11 @@ Server.prototype = {
       for (let option of forceOptions) {
 
         // Add numeric options right away and look up alias names
+        let id;
         if (isNaN(option)) {
-          const id = Options.conf[option];
+          id = Options.conf[option];
         } else {
-          const id = option;
+          id = option;
         }
 
         // Add option if it is valid and not present yet


### PR DESCRIPTION
When using `dhcp@0.2.14` I got the following error: 
```
        if (id !== undefined && pre[id] === undefined) {
        ^

ReferenceError: id is not defined
```