### PR TITLE
Update seqbuffer.js

### DIFF
--- a/lib/seqbuffer.js
+++ b/lib/seqbuffer.js
@@ -17,7 +17,7 @@ function trimZero(str) {
 
 function SeqBuffer(buf, len) {
 
-  this._data = buf || Buffer.alloc(len || 1500); // alloc() fills the buffer with '0'
+  this._data = buf || Buffer.alloc(len || 1400); // alloc() fills the buffer with '0'
 }
 
 SeqBuffer.prototype = {


### PR DESCRIPTION
The maximum packet size of DHCP is 1400 bytes.
So why you should set it on 1500?
It causes problems for developers that use your protocol.js for decoding and encoding packets.
I know that they can slice buffer with _w pointer but we can make it easier and more reasonable.