### PR TITLE
Refactor variable interface

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -595,8 +595,8 @@ Client.prototype = {
 
         const interfaces = os.networkInterfaces();
 
-        for (let interface in interfaces) {
-          const addresses = interfaces[interface];
+        for (let intf in interfaces) {
+          const addresses = interfaces[intf];
           for (let address in addresses) {
             if (addresses[address].family === 'IPv4' && !addresses[address].internal) {
 


### PR DESCRIPTION
Some NodeJS versions do not support the term "interface" as a variable
as it is a reserved keyword.

Specifically Node 6.9.5 does not support this version.

This change removes the "interface" variable name and replaces it with "intf"