### PR TITLE
Add ignore range to options

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -366,7 +366,7 @@ Server.prototype = {
     lease.server = this.config('server');
     lease.state = 'OFFERED';
 
-    if(lease.addres) {
+    if(lease.address) {
       this.sendOffer(req);
     }
   },
@@ -413,7 +413,7 @@ Server.prototype = {
     lease.state = 'BOUND';
     lease.bindTime = new Date;
 
-    if(lease.addres) {
+    if(lease.address) {
       this.sendAck(req);
     }
   },

--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -287,7 +287,10 @@ Server.prototype = {
     } else if (_static[clientMAC]) {
       return _static[clientMAC];
     }
-
+    
+    const _ignoreRange = this.config('ignoreRange');
+    if(_ignoreRange)
+      return false;
 
     const randIP = this.config('randomIP');
     const _tmp = this.config('range');
@@ -363,7 +366,9 @@ Server.prototype = {
     lease.server = this.config('server');
     lease.state = 'OFFERED';
 
-    this.sendOffer(req);
+    if(lease.addres) {
+      this.sendOffer(req);
+    }
   },
   sendOffer: function(req) {
 
@@ -408,7 +413,9 @@ Server.prototype = {
     lease.state = 'BOUND';
     lease.bindTime = new Date;
 
-    this.sendAck(req);
+    if(lease.addres) {
+      this.sendAck(req);
+    }
   },
   sendAck: function(req) {
     //console.log('Send ACK');

--- a/lib/options.js
+++ b/lib/options.js
@@ -537,6 +537,12 @@ const opts = {
     type: 'Bool',
     config: 'randomIP',
     default: true
+  },
+  9999: {
+    name: 'Ignore Range',
+    type: 'Bool',
+    config: 'ignoreRange',
+    default: false
   }
 };
 


### PR DESCRIPTION
If ignore range is set to true, the server will ignore to reply the client.
This is for the dhcp server that want to give static ip address to specific mac address only.