### PR TITLE
Added DHCPINFORM response for testing WPAD.

### DIFF
--- a/lib/dhcp.js
+++ b/lib/dhcp.js
@@ -95,6 +95,9 @@ function Server(config, listenOnly) {
         case DHCPREQUEST: // 3.
           self.handleRequest(req);
           break;
+        case DHCPINFORM: // 8.
+          self.handleInform(req);
+          break;
         default:
           console.error("Not implemented method", req.options[53]);
       }
@@ -409,6 +412,36 @@ Server.prototype = {
     lease.bindTime = new Date;
 
     this.sendAck(req);
+  },
+  handleInform: function(req) {
+    //console.log('Handle Inform', req);
+
+    // Formulate the response object
+    const ans = {
+      op: BOOTREPLY,
+      htype: 1, // RFC1700, hardware types: 1=Ethernet, 2=Experimental, 3=AX25, 4=ProNET Token Ring, 5=Chaos, 6=Tokenring, 7=Arcnet, 8=FDDI, 9=Lanstar (keep it constant)
+      hlen: 6, // Mac addresses are 6 byte
+      hops: 0,
+      xid: req.xid, // 'xid' from client DHCPREQUEST message
+      secs: 0,
+      flags: req.flags, // 'flags' from client DHCPREQUEST message
+      ciaddr: INADDR_ANY,
+      yiaddr: INADDR_ANY,
+      siaddr: this.config('server'), // server ip, that's us
+      giaddr: req.giaddr, // 'giaddr' from client DHCPREQUEST message
+      chaddr: req.chaddr, // 'chaddr' from client DHCPREQUEST message
+      sname: '',
+      file: '',
+      options: this._getOptions({
+        53: DHCPACK
+      }, [
+        1, 3, 51, 54, 6
+      ], req.options[55])
+    };
+
+    // Send the actual data
+    // INADDR_BROADCAST : 68 <- SERVER_IP : 67
+    this._send(INADDR_BROADCAST, ans);
   },
   sendAck: function(req) {
     //console.log('Send ACK');


### PR DESCRIPTION
With this PR, I am able to get the WPAD using DHCPINFORM. 

Here is are my client and server configs if anybody finds them useful.
```js
var s = dhcpd.createServer({
  // System settings
  range: [
    "192.168.3.10", "192.168.3.99"
  ],
  forceOptions: ['hostname', 'wpad'], // Options that need to be sent, even if they were not requested
  // Option settings
  hostname: "kacknup",
  server: '192.168.0.1', // This is us
  wpad: 'http://wpad.com/wpad.dat'
});

var s = dhcp.createClient({
  mac: "11:22:33:44:55:66", 
  features: ['wpad']
});
```
